### PR TITLE
table: fix to compare new best path with old best path

### DIFF
--- a/table/destination.go
+++ b/table/destination.go
@@ -252,8 +252,26 @@ func (dest *Destination) Calculate(ids []string) (map[string]*Path, []*Path) {
 			}
 			return nil
 		}()
+		equal := func(lhs, rhs *Path) bool {
+			// already know the NLRIs are same and
+			// timestamp must be ignored so check out only
+			// source.
+			if lhs.GetSource() != rhs.GetSource() {
+				return false
+			}
+
+			pattrs := func(arg []bgp.PathAttributeInterface) []byte {
+				ret := make([]byte, 0)
+				for _, a := range arg {
+					aa, _ := a.Serialize()
+					ret = append(ret, aa...)
+				}
+				return ret
+			}
+			return bytes.Equal(pattrs(lhs.GetPathAttrs()), pattrs(rhs.GetPathAttrs()))
+		}
 		best := dest.GetBestPath(id)
-		if best != nil && best.Equal(old) {
+		if best != nil && old != nil && equal(best, old) {
 			return nil
 		}
 		if best == nil {


### PR DESCRIPTION
The current code uses Path.Equal(), which just check out if pathes are
idential. However, it doesn't work for two cloned pathes of a path
(soft update in case).

This commit is the modified version of:

https://github.com/osrg/gobgp/commit/74c0527dda13032dabd5dd4b7034115827fd2a46

Signed-off-by: FUJITA Tomonori fujita.tomonori@lab.ntt.co.jp
