### PR TITLE
packet/bgp: make serialization of ipv4/v6 nlri goroutine-safe (MF custom)

### DIFF
--- a/packet/bgp/bgp_test.go
+++ b/packet/bgp/bgp_test.go
@@ -61,10 +61,17 @@ func Test_Message(t *testing.T) {
 func Test_IPAddrPrefixString(t *testing.T) {
 	ipv4 := NewIPAddrPrefix(24, "129.6.10.0")
 	assert.Equal(t, "129.6.10.0/24", ipv4.String())
-	ipv6 := NewIPv6AddrPrefix(18, "3343:faba:3903::1")
-	assert.Equal(t, "3343:faba:3903::1/18", ipv6.String())
-	ipv6 = NewIPv6AddrPrefix(18, "3343:faba:3903::0")
-	assert.Equal(t, "3343:faba:3903::/18", ipv6.String())
+	ipv4 = NewIPAddrPrefix(24, "129.6.10.1")
+	assert.Equal(t, "129.6.10.0/24", ipv4.String())
+	ipv4 = NewIPAddrPrefix(22, "129.6.129.0")
+	assert.Equal(t, "129.6.128.0/22", ipv4.String())
+
+	ipv6 := NewIPv6AddrPrefix(64, "3343:faba:3903::0")
+	assert.Equal(t, "3343:faba:3903::/64", ipv6.String())
+	ipv6 = NewIPv6AddrPrefix(64, "3343:faba:3903::1")
+	assert.Equal(t, "3343:faba:3903::/64", ipv6.String())
+	ipv6 = NewIPv6AddrPrefix(63, "3343:faba:3903:129::0")
+	assert.Equal(t, "3343:faba:3903:128::/63", ipv6.String())
 }
 
 func Test_RouteTargetMembershipNLRIString(t *testing.T) {
@@ -560,7 +567,7 @@ func Test_CompareFlowSpecNLRI(t *testing.T) {
 
 func Test_MpReachNLRIWithIPv4MappedIPv6Prefix(t *testing.T) {
 	assert := assert.New(t)
-	n1 := NewIPv6AddrPrefix(120, "::ffff:10.0.0.1")
+	n1 := NewIPv6AddrPrefix(120, "::ffff:10.0.0.0")
 	buf1, err := n1.Serialize()
 	assert.Nil(err)
 	n2, err := NewPrefixFromRouteFamily(RouteFamilyToAfiSafi(RF_IPv6_UC))
@@ -579,7 +586,7 @@ func Test_MpReachNLRIWithIPv4MappedIPv6Prefix(t *testing.T) {
 
 	label := NewMPLSLabelStack(2)
 
-	n3 := NewLabeledIPv6AddrPrefix(120, "::ffff:10.0.0.1", *label)
+	n3 := NewLabeledIPv6AddrPrefix(120, "::ffff:10.0.0.0", *label)
 	buf1, err = n3.Serialize()
 	assert.Nil(err)
 	n4, err := NewPrefixFromRouteFamily(RouteFamilyToAfiSafi(RF_IPv6_MPLS))

--- a/packet/bgp/helper.go
+++ b/packet/bgp/helper.go
@@ -30,10 +30,8 @@ func NewTestBGPOpenMessage() *BGPMessage {
 			[]*CapGracefulRestartTuple{g})})
 	p4 := NewOptionParameterCapability(
 		[]ParameterCapabilityInterface{NewCapFourOctetASNumber(100000)})
-	p5 := NewOptionParameterCapability(
-		[]ParameterCapabilityInterface{NewCapAddPath(RF_IPv4_UC, BGP_ADD_PATH_BOTH)})
 	return NewBGPOpenMessage(11033, 303, "100.4.10.3",
-		[]OptionParameterInterface{p1, p2, p3, p4, p5})
+		[]OptionParameterInterface{p1, p2, p3, p4})
 }
 
 func NewTestBGPUpdateMessage() *BGPMessage {
@@ -78,16 +76,16 @@ func NewTestBGPUpdateMessage() *BGPMessage {
 	}
 
 	mp_nlri := []AddrPrefixInterface{
-		NewLabeledVPNIPAddrPrefix(20, "192.0.9.0", *NewMPLSLabelStack(1, 2, 3),
+		NewLabeledVPNIPAddrPrefix(24, "192.0.9.0", *NewMPLSLabelStack(1, 2, 3),
 			NewRouteDistinguisherTwoOctetAS(256, 10000)),
-		NewLabeledVPNIPAddrPrefix(26, "192.10.8.192", *NewMPLSLabelStack(5, 6, 7, 8),
+		NewLabeledVPNIPAddrPrefix(24, "192.10.8.0", *NewMPLSLabelStack(5, 6, 7, 8),
 			NewRouteDistinguisherIPAddressAS("10.0.1.1", 10001)),
 	}
 
-	mp_nlri2 := []AddrPrefixInterface{NewIPv6AddrPrefix(100,
+	mp_nlri2 := []AddrPrefixInterface{NewIPv6AddrPrefix(128,
 		"fe80:1234:1234:5667:8967:af12:8912:1023")}
 
-	mp_nlri3 := []AddrPrefixInterface{NewLabeledVPNIPv6AddrPrefix(100,
+	mp_nlri3 := []AddrPrefixInterface{NewLabeledVPNIPv6AddrPrefix(128,
 		"fe80:1234:1234:5667:8967:af12:1203:33a1", *NewMPLSLabelStack(5, 6),
 		NewRouteDistinguisherFourOctetAS(5, 6))}
 


### PR DESCRIPTION
Fix the serialization according to osrg/gobgp cda7c44.